### PR TITLE
Apply aarch64 relative relocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 **/*.macho
+**/*.map

--- a/fw/.cargo/config.toml
+++ b/fw/.cargo/config.toml
@@ -2,4 +2,12 @@
 target = "aarch64-unknown-none-softfloat"
 
 [target.aarch64-unknown-none-softfloat]
-rustflags = ["-C", "link-arg=-Tp1c0.ld"]
+rustflags = [
+    "-C", "link-arg=-Tp1c0.ld",
+    "-C", "link-arg=-Map=p1c0.map",
+    "-C", "relocation-model=pic",
+    "-C", "link-arg=--no-apply-dynamic-relocs",
+    "-C", "link-arg=-pie",
+    "-C", "link-args=-z nocopyreloc",
+    "-C", "link-args=-z notext"
+]

--- a/fw/p1c0.ld
+++ b/fw/p1c0.ld
@@ -152,6 +152,7 @@ SECTIONS {
         *(.rela.data)
         *(.rela.data.*)
         *(.rela.dyn)
+        *(.rela.*)
         _rela_end = .;
         . = ALIGN(0x4000);
     } :rodata

--- a/fw/startup.S
+++ b/fw/startup.S
@@ -8,7 +8,7 @@
 .globl _start
 .type _start, @function
 _start:
-    mov x9, x0
+    mov x19, x0
 
 _clear_bss:
     adrp x0, _bss_start
@@ -26,9 +26,19 @@ _configure_stack:
     adrp x1, _stack_bot
     mov sp, x1
 
+_apply_relocations:
+    adrp x0, _base
+    mov x20, x0
+    adrp x1, _rela_start
+    add x1, x1, :lo12:_rela_start
+    adrp x2, _rela_end
+    add x2, x2, :lo12:_rela_end
+    sub x2, x2, x1
+    bl apply_rela
+
 _jump_to_kernel_main:
-    mov x0, x9
-    mov x1, x10
+    mov x0, x19
+    mov x1, x20
     bl kernel_main
 
 _infinite_loop:

--- a/m1/src/arch.rs
+++ b/m1/src/arch.rs
@@ -1,0 +1,31 @@
+#[repr(C)]
+pub struct RelaEntry {
+    offset: usize,
+    ty: usize,
+    addend: usize,
+}
+
+const R_AARCH64_RELATIVE: usize = 1027;
+
+/// Applies relative offsets during boot to relocate the binary.
+/// SAFETY:
+///   * rela_start must point to valid memory, at the start of the relocatable information
+///   * rela_len_bytes must be larger than 0 and indicate the size of the slice in bytes.
+///   * Other regular conditions must hold when calling thsi function (e.g.: having a valid SP)
+#[no_mangle]
+pub unsafe extern "C" fn apply_rela(
+    base: usize,
+    rela_start: *const RelaEntry,
+    rela_len_bytes: usize,
+) {
+    let rela_len = rela_len_bytes / core::mem::size_of::<RelaEntry>();
+    let relocations = &*core::ptr::slice_from_raw_parts(rela_start, rela_len);
+
+    for relocation in relocations {
+        let ptr = (base + relocation.offset) as *mut usize;
+        match relocation.ty {
+            R_AARCH64_RELATIVE => *ptr = base + relocation.addend,
+            _ => unimplemented!(),
+        };
+    }
+}

--- a/m1/src/lib.rs
+++ b/m1/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), no_std)]
 
+pub mod arch;
 pub mod boot_args;
 pub mod display;


### PR DESCRIPTION
Make the binary position independent. This means we will also need to
handle relocations.

Since the code is mapped into memory in a random virtual address,
relocations need to be applied during boot to make sure all jumps and
offsets are still valid.