### PR TITLE
Allocate display memory dynamically

### DIFF
--- a/fw/p1c0.ld
+++ b/fw/p1c0.ld
@@ -3,8 +3,7 @@ ENTRY(_start)
 /* Fake virtual load address for the mach-o */
 _va_base = 0xFFFFFE0007004000;
 
-/* Huge stack for now, as we don't have dyn memory yet and the framebuffer is in the stack */
-_stack_size = 0x8000000;
+_stack_size = 0x8000;
 
 /* 4 GB arena size */
 _arena_size = 0x100000000;

--- a/m1/src/collections.rs
+++ b/m1/src/collections.rs
@@ -1,0 +1,40 @@
+extern crate alloc;
+
+use alloc::alloc::Global;
+use alloc::vec::Vec;
+
+use core::alloc::{AllocError, Allocator, Layout};
+
+use core::ptr::NonNull;
+
+#[repr(transparent)]
+pub struct AlignedAllocator<A: Allocator, const ALIGNMENT: usize> {
+    inner: A,
+}
+
+impl<const ALIGNMENT: usize> AlignedAllocator<Global, ALIGNMENT> {
+    pub fn new() -> Self {
+        Self { inner: Global }
+    }
+}
+
+unsafe impl<A: Allocator, const ALIGNMENT: usize> Allocator for AlignedAllocator<A, ALIGNMENT> {
+    fn allocate(&self, mut layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        if layout.align() < ALIGNMENT {
+            layout = layout.align_to(ALIGNMENT).expect("Can be aligned");
+        }
+        self.inner.allocate(layout)
+    }
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, mut layout: Layout) {
+        if layout.align() < ALIGNMENT {
+            layout = layout.align_to(ALIGNMENT).expect("Can be aligned");
+        }
+        self.inner.deallocate(ptr, layout);
+    }
+}
+
+pub type AlignedVec<T, const ALIGNMENT: usize> = Vec<T, AlignedAllocator<Global, ALIGNMENT>>;
+
+pub fn new_aligned_vector<T, const ALIGNMENT: usize>() -> AlignedVec<T, ALIGNMENT> {
+    AlignedVec::new_in(AlignedAllocator::new())
+}

--- a/m1/src/lib.rs
+++ b/m1/src/lib.rs
@@ -1,8 +1,9 @@
 #![cfg_attr(not(test), no_std)]
-#![feature(global_asm, asm)]
+#![feature(global_asm, asm, allocator_api)]
 
 pub mod arch;
 pub mod boot_args;
+mod collections;
 pub mod display;
 pub mod font;
 pub mod uart;


### PR DESCRIPTION
This allows to reduce the stack size since now the display is no longer
constructed on the stack.