### PR TITLE
Update cortex-a crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,8 +22,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cortex-a"
-version = "6.1.0"
-source = "git+https://github.com/Javier-varez/cortex-a.git?branch=fix_core_arch_asm#06950d997f02cede432a0ab861f16c142e007626"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b27f5d071b671f9799dfdf0c0afcec11de65195383d36e186639c83b00705e4f"
 dependencies = [
  "tock-registers",
 ]

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -28,8 +28,9 @@ checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cortex-a"
-version = "6.1.0"
-source = "git+https://github.com/Javier-varez/cortex-a.git?branch=fix_core_arch_asm#06950d997f02cede432a0ab861f16c142e007626"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b27f5d071b671f9799dfdf0c0afcec11de65195383d36e186639c83b00705e4f"
 dependencies = [
  "tock-registers",
 ]

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 m1 = { path = "../m1" }
 embedded-graphics = "0.7.1"
 tinybmp = "0.3.1"
-cortex-a = { git = "https://github.com/Javier-varez/cortex-a.git", branch = "fix_core_arch_asm", version = "6.1.0" }
+cortex-a = "7.0.0"
 tock-registers = "0.7.0"
 
 [build-dependencies]

--- a/m1/Cargo.toml
+++ b/m1/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 spin = "0.9.2"
 embedded-graphics = "0.7.1"
-cortex-a = { git = "https://github.com/Javier-varez/cortex-a.git", branch = "fix_core_arch_asm", version = "6.1.0" }
+cortex-a = "7.0.0"
 tock-registers = "0.7.0"


### PR DESCRIPTION
After the bug regarding the path for the asm! macro usage in the
cortex-a crate, a new release has been issued to fix the problem, so we
don't need the tracked version from my github account.