### PR TITLE
Increase stack size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target
 **/*.macho
 **/*.map
+**/.DS_Store

--- a/fw/p1c0.ld
+++ b/fw/p1c0.ld
@@ -3,7 +3,7 @@ ENTRY(_start)
 /* Fake virtual load address for the mach-o */
 _va_base = 0xFFFFFE0007004000;
 
-_stack_size = 0x8000;
+_stack_size = 0x80000;
 
 /* 4 GB arena size */
 _arena_size = 0x100000000;


### PR DESCRIPTION
Debug builds use quite a bit of stack and that causes a stack overflow
when configuring the MMU. In the future we should be able to catch
theses issues by having a carveout of one page in VM at the end of the
stack before the data/bss section starts, although it still wouldn't fix
a stack overlow before the MMU is setup.