### PR TITLE
Reduce bloat in LevelTable

### DIFF
--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -45,7 +45,7 @@ pub extern "C" fn kernel_main() {
 
     println!("p1c0 running on Apple M1 Pro");
     println!("Exception level: {:?}", m1::arch::get_exception_level());
-    println!("");
+    println!();
 
     let boot_args = get_boot_args();
     print_boot_args(boot_args);


### PR DESCRIPTION
Introducing another u8 in the LevelTable struct causes it to double the
allocation size (due to the alignment requirement to a page size).

Instead, we can simply keep track of the individual levels when
traversing the tree, saving half of the memory.

Reduce also the size of the early memory allocator to 64 kB.