### PR TITLE
Introduce arm-semihosting crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,4 @@
 [alias]
 xtask = "run --manifest-path ./xtask/Cargo.toml --"
 rr = "run --manifest-path ./xtask/Cargo.toml -- run --release"
+br = "run --manifest-path ./xtask/Cargo.toml -- build --release"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,10 @@
 version = 3
 
 [[package]]
+name = "arm-semihosting"
+version = "0.1.0"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 
 members = [
-    "m1"
+    "m1",
+    "arm_semihosting"
 ]
 
 exclude = [

--- a/arm_semihosting/Cargo.toml
+++ b/arm_semihosting/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "arm-semihosting"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/arm_semihosting/src/arch/aarch64.rs
+++ b/arm_semihosting/src/arch/aarch64.rs
@@ -1,0 +1,21 @@
+use crate::{HostResult, Operation};
+
+use core::arch::asm;
+
+#[inline]
+pub fn call_host(op: &Operation) -> HostResult {
+    let op_code = op.code();
+    let args = op.args();
+    let mut result: usize;
+
+    unsafe {
+        asm!(
+            "hlt #0xF000",
+            in("w0") op_code,
+            in("x1") args,
+            lateout("x0") result
+        )
+    }
+
+    HostResult(result)
+}

--- a/arm_semihosting/src/arch/arm.rs
+++ b/arm_semihosting/src/arch/arm.rs
@@ -1,0 +1,21 @@
+use crate::{HostResult, Operation};
+
+use core::arch::asm;
+
+#[inline]
+#[cfg_attr(target_cpu = "arm", instruction_set(arm::a32))]
+pub fn call_host(op: &Operation) -> HostResult {
+    let op_code = op.code();
+    let args = op.args();
+    let mut result: usize;
+
+    unsafe {
+        asm!(
+            "svc #0x123456",
+            inlateout("r0") op_code => result,
+            in("r1") args,
+        )
+    }
+
+    HostResult(result)
+}

--- a/arm_semihosting/src/arch/x86.rs
+++ b/arm_semihosting/src/arch/x86.rs
@@ -1,0 +1,6 @@
+use crate::{HostResult, Operation};
+
+#[inline]
+pub fn call_host(_op: &Operation) -> HostResult {
+    HostResult(0)
+}

--- a/arm_semihosting/src/lib.rs
+++ b/arm_semihosting/src/lib.rs
@@ -1,0 +1,64 @@
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(target_arch = "arm", feature(isa_attribute))]
+
+#[cfg_attr(target_arch = "aarch64", path = "arch/aarch64.rs")]
+#[cfg_attr(target_arch = "arm", path = "arch/arm.rs")]
+#[cfg_attr(any(target_arch = "x86", target_arch = "x86_64"), path = "arch/x86.rs")]
+pub mod arch;
+
+#[repr(usize)]
+pub enum ExitReason {
+    ApplicationExit = 0x20026,
+    InternalError = 0x20024,
+}
+
+#[repr(usize)]
+pub enum Operation {
+    SysExit(ExitArgs),
+    SysExitExtended(ExitArgs),
+}
+
+#[repr(C)]
+pub struct ExitArgs {
+    sh_reason: ExitReason,
+    exit_code: usize,
+}
+
+trait PointerArgs {
+    #[inline]
+    fn get_args(&self) -> usize {
+        self as *const _ as *const () as usize
+    }
+}
+
+impl PointerArgs for ExitArgs {}
+
+impl Operation {
+    #[inline]
+    fn code(&self) -> usize {
+        match *self {
+            Operation::SysExit(_) => 0x18,
+            Operation::SysExitExtended(_) => 0x20,
+        }
+    }
+
+    #[inline]
+    fn args(&self) -> usize {
+        match self {
+            Operation::SysExit(args) => args.get_args(),
+            Operation::SysExitExtended(args) => args.get_args(),
+        }
+    }
+}
+
+pub struct HostResult(usize);
+
+pub fn exit(exit_code: u32) -> ! {
+    let op = Operation::SysExitExtended(ExitArgs {
+        sh_reason: ExitReason::ApplicationExit,
+        exit_code: exit_code as usize,
+    });
+
+    arch::call_host(&op);
+    unreachable!();
+}

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -3,6 +3,10 @@
 version = 3
 
 [[package]]
+name = "arm-semihosting"
+version = "0.1.0"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +125,7 @@ dependencies = [
 name = "p1c0"
 version = "0.1.0"
 dependencies = [
+ "arm-semihosting",
  "cc",
  "cortex-a",
  "embedded-graphics",

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -5,12 +5,17 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+emulator = ["arm-semihosting"]
+default = []
+
 [dependencies]
 m1 = { path = "../m1" }
 embedded-graphics = "0.7.1"
 tinybmp = "0.3.1"
 cortex-a = "7.0.0"
 tock-registers = "0.7.0"
+arm-semihosting = { path = "../arm_semihosting", optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -14,6 +14,11 @@ const ATE_LOGO_DATA: &[u8] = include_bytes!("../ate_logo.bmp");
 #[panic_handler]
 fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
     println!("Panicked with message: {:?}", panic_info);
+
+    #[cfg(feature = "emulator")]
+    arm_semihosting::exit(1);
+
+    #[cfg(not(feature = "emulator"))]
     loop {}
 }
 
@@ -39,7 +44,7 @@ fn print_boot_args(boot_args: &BootArgs) {
 }
 
 #[no_mangle]
-pub extern "C" fn kernel_main() {
+pub extern "C" fn kernel_main() -> ! {
     let logo = Bmp::<Rgb888>::from_slice(ATE_LOGO_DATA).unwrap();
     Display::init(&logo);
 
@@ -54,4 +59,10 @@ pub extern "C" fn kernel_main() {
     println!("let's cause a page fault!");
     let val = unsafe { *addr };
     println!("Hah, value is {}", val);
+
+    #[cfg(feature = "emulator")]
+    arm_semihosting::exit(0);
+
+    #[cfg(not(feature = "emulator"))]
+    loop {}
 }

--- a/m1/Cargo.toml
+++ b/m1/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+semihosting = []
+default = []
+
 [dependencies]
 spin = "0.9.2"
 embedded-graphics = "0.7.1"


### PR DESCRIPTION
This will allow using qemu in a hosted environment to run tests with a
custom test framework. For now, another build has been created to use
the semihosting implementation and run the application under qemu.