### PR TITLE
Fix peripherals not responding to mmio access

### DIFF
--- a/m1/src/arch/mmu.rs
+++ b/m1/src/arch/mmu.rs
@@ -452,7 +452,7 @@ impl MemoryManagementUnit {
             VirtualAddress::new(mmio_region_base).expect("Address is aligned to page size"),
             PhysicalAddress::new(mmio_region_base).expect("Address is aligned to page size"),
             mmio_region_size,
-            Attributes::DevicenGnRE,
+            Attributes::DevicenGnRnE,
             Permissions::RWX,
         )
         .expect("No other mapping overlaps");
@@ -463,7 +463,7 @@ impl MemoryManagementUnit {
             VirtualAddress::new(mmio_region_base).expect("Address is aligned to page size"),
             PhysicalAddress::new(mmio_region_base).expect("Address is aligned to page size"),
             mmio_region_size,
-            Attributes::DevicenGnRE,
+            Attributes::DevicenGnRnE,
             Permissions::RWX,
         )
         .expect("No other mapping overlaps");
@@ -474,7 +474,7 @@ impl MemoryManagementUnit {
             VirtualAddress::new(mmio_region_base).expect("Address is aligned to page size"),
             PhysicalAddress::new(mmio_region_base).expect("Address is aligned to page size"),
             mmio_region_size,
-            Attributes::DevicenGnRE,
+            Attributes::DevicenGnRnE,
             Permissions::RWX,
         )
         .expect("No other mapping overlaps");


### PR DESCRIPTION
When the MMU was enabled peripherals were not responding to MMU writes.
For instance, the watchdog could not be serviced after the MMU was
enabled.

It seems that doing early write acknowledge does not work at all.