### PR TITLE
Start moving towards generic driver interfaces

### DIFF
--- a/fw/src/lib.rs
+++ b/fw/src/lib.rs
@@ -59,7 +59,10 @@ pub extern "C" fn kernel_main() {
 #[cfg(test)]
 mod tests {
     use super::print_boot_args;
-    use p1c0_kernel::{boot_args::get_boot_args, drivers::generic_timer::get_timer};
+    use p1c0_kernel::{
+        boot_args::get_boot_args,
+        drivers::{generic_timer::get_timer, interfaces::timer::Timer},
+    };
 
     #[test_case]
     fn test_print_boot_args() {
@@ -70,11 +73,11 @@ mod tests {
     fn test_system_timer() {
         let timer = get_timer();
         let resolution = timer.resolution();
-        crate::println!("Timer resolution is {}", resolution);
+        crate::println!("Timer resolution is {:?}", resolution);
         let old_ticks = timer.ticks();
-        crate::println!("Timer ticks is {}", old_ticks);
+        crate::println!("Timer ticks is {:?}", old_ticks);
         let new_ticks = timer.ticks();
-        crate::println!("Timer ticks is {}", new_ticks);
+        crate::println!("Timer ticks is {:?}", new_ticks);
         assert!(new_ticks > old_ticks);
     }
 }

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -10,7 +10,9 @@ use p1c0::print_boot_args;
 use p1c0_kernel::{
     arch::get_exception_level,
     boot_args::get_boot_args,
-    drivers::{display::Display, gpio::GpioBank, hid::HidDev, spi::Spi, wdt},
+    drivers::{
+        display::Display, gpio::GpioBank, hid::HidDev, interfaces::timer::Timer, spi::Spi, wdt,
+    },
     println,
     syscall::Syscall,
     thread::{self, print_thread_info},

--- a/fw/tests/thread_tests.rs
+++ b/fw/tests/thread_tests.rs
@@ -6,8 +6,13 @@
 #![feature(default_alloc_error_handler)]
 
 use core::time::Duration;
-use p1c0 as _; // needed to link libentry (and _start)
-use p1c0_kernel::{drivers::generic_timer::get_timer, sync::spinlock::SpinLock, thread};
+use p1c0 as _;
+// needed to link libentry (and _start)
+use p1c0_kernel::{
+    drivers::{generic_timer::get_timer, interfaces::timer::Timer},
+    sync::spinlock::SpinLock,
+    thread,
+};
 
 #[panic_handler]
 fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {

--- a/p1c0_kernel/src/arch/exceptions.rs
+++ b/p1c0_kernel/src/arch/exceptions.rs
@@ -5,6 +5,8 @@ use tock_registers::{
     registers::InMemoryRegister,
 };
 
+use crate::drivers::interfaces::timer::Timer;
+
 #[cfg(all(target_os = "none", target_arch = "aarch64", not(test)))]
 use core::arch::global_asm;
 

--- a/p1c0_kernel/src/drivers/hid.rs
+++ b/p1c0_kernel/src/drivers/hid.rs
@@ -2,6 +2,7 @@ pub mod keyboard;
 
 use super::generic_timer;
 use super::gpio::{self, GpioBank, PinState};
+use super::interfaces::timer::Timer;
 use super::spi::{self, Spi};
 
 use crate::adt;

--- a/p1c0_kernel/src/drivers/interfaces/mod.rs
+++ b/p1c0_kernel/src/drivers/interfaces/mod.rs
@@ -1,0 +1,42 @@
+use core::time::Duration;
+
+pub mod timer;
+
+/// The current number of ticks the timer has made since boot
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
+pub struct Ticks(u64);
+
+impl Ticks {
+    /// This method is only recommended for implementors of the Timer trait. If you REALLY insist in
+    /// using this method, at least make sure that the ticks really mean something to the driver
+    pub(super) fn new(raw_ticks: u64) -> Ticks {
+        Self(raw_ticks)
+    }
+}
+
+/// Resolution for a timer.
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
+pub struct TimerResolution(u64);
+
+impl TimerResolution {
+    const S_IN_NS: u128 = 1_000_000_000;
+
+    pub(super) fn from_hz(hz: u64) -> TimerResolution {
+        TimerResolution(hz)
+    }
+
+    pub fn into_hz(self) -> u64 {
+        self.0
+    }
+    pub fn into_duration(self) -> Duration {
+        Duration::from_nanos(Self::S_IN_NS as u64 / self.0)
+    }
+
+    pub fn ticks_to_duration(&self, ticks: Ticks) -> Duration {
+        Duration::from_nanos(((ticks.0 as u128 * Self::S_IN_NS) / self.0 as u128) as u64)
+    }
+
+    pub fn duration_to_ticks(&self, duration: Duration) -> Ticks {
+        Ticks(((duration.as_nanos() as u128 * self.0 as u128) / Self::S_IN_NS as u128) as u64)
+    }
+}

--- a/p1c0_kernel/src/drivers/interfaces/timer.rs
+++ b/p1c0_kernel/src/drivers/interfaces/timer.rs
@@ -1,0 +1,23 @@
+use super::{Ticks, TimerResolution};
+
+pub trait Timer {
+    /// Initializes the timer to run at a fixed jiffy interval. This is not related to the timer
+    /// resolution, which can and should be much higher than the interval
+    fn initialize(&self, interval: core::time::Duration);
+
+    /// Returns the resolution of the timer frequency in Mhz
+    fn resolution(&self) -> TimerResolution;
+    fn ticks(&self) -> Ticks;
+    fn handle_irq(&self);
+    fn is_irq_active(&self) -> bool;
+
+    /// Delays execution for the given duration. Currently this is a blocking routine that does not
+    /// sleep, just simply spins
+    fn delay(&self, time: core::time::Duration) {
+        const S_TO_NS: u128 = 1_000_000_000;
+        let ticks = ((self.resolution().into_hz() as u128 * time.as_nanos()) / S_TO_NS) as u64;
+        let start = self.ticks().0;
+
+        while self.ticks().0 < (start + ticks) {}
+    }
+}

--- a/p1c0_kernel/src/drivers/mod.rs
+++ b/p1c0_kernel/src/drivers/mod.rs
@@ -1,3 +1,5 @@
+pub mod interfaces;
+
 pub mod aic;
 pub mod display;
 pub mod generic_timer;

--- a/p1c0_kernel/src/drivers/spi.rs
+++ b/p1c0_kernel/src/drivers/spi.rs
@@ -6,7 +6,7 @@ use tock_registers::{
 
 use crate::{
     adt::get_adt,
-    drivers::generic_timer,
+    drivers::{generic_timer, interfaces::timer::Timer},
     memory::{address::Address, MemoryManager},
 };
 

--- a/p1c0_kernel/src/init.rs
+++ b/p1c0_kernel/src/init.rs
@@ -10,7 +10,7 @@ use crate::{
     arch::{apply_rela_from_existing, exceptions, jump_to_addr, read_pc, RelaEntry},
     boot_args::BootArgs,
     chickens,
-    drivers::{aic, generic_timer, uart, wdt},
+    drivers::{aic, generic_timer, interfaces::timer::Timer, uart, wdt},
     memory::{
         self,
         address::{Address, PhysicalAddress},


### PR DESCRIPTION
Let's try to decouple implementations from interfaces. At this point I
didn't bother much, but this should be the direction in the future to
avoid too much coupling between modules.