### PR TITLE
Make sure stack is 16-byte aligned

### DIFF
--- a/p1c0_kernel/src/arch/exceptions.s
+++ b/p1c0_kernel/src/arch/exceptions.s
@@ -7,30 +7,31 @@
 
 .macro el1_save_context_and_call_handler handler stringlabel
     // push all general purpose registers on the stack.
-    str x30, [sp, #-8]!
-    stp x28, x29, [sp, #-16]!
-    stp x26, x27, [sp, #-16]!
-    stp x24, x25, [sp, #-16]!
-    stp x22, x23, [sp, #-16]!
-    stp x20, x21, [sp, #-16]!
-    stp x18, x19, [sp, #-16]!
-    stp x16, x17, [sp, #-16]!
-    stp x14, x15, [sp, #-16]!
-    stp x12, x13, [sp, #-16]!
-    stp x10, x11, [sp, #-16]!
-    stp x8,  x9,  [sp, #-16]!
-    stp x6,  x7,  [sp, #-16]!
-    stp x4,  x5,  [sp, #-16]!
-    stp x2,  x3,  [sp, #-16]!
-    stp x0,  x1,  [sp, #-16]!
+    sub sp, sp, 0x120
+    str x30, [sp, #0x110]
+    stp x28, x29, [sp, #0x100]
+    stp x26, x27, [sp, #0xF0]
+    stp x24, x25, [sp, #0xE0]
+    stp x22, x23, [sp, #0xD0]
+    stp x20, x21, [sp, #0xC0]
+    stp x18, x19, [sp, #0xB0]
+    stp x16, x17, [sp, #0xA0]
+    stp x14, x15, [sp, #0x90]
+    stp x12, x13, [sp, #0x80]
+    stp x10, x11, [sp, #0x70]
+    stp x8,  x9,  [sp, #0x60]
+    stp x6,  x7,  [sp, #0x50]
+    stp x4,  x5,  [sp, #0x40]
+    stp x2,  x3,  [sp, #0x30]
+    stp x0,  x1,  [sp, #0x20]
 
     mrs x1,  ELR_EL1
     mrs x2,  SPSR_EL1
     mrs x3,  ESR_EL1
     mrs x4,  SP_EL0
 
-    stp x3, x4, [sp, #-16]!
-    stp x1, x2, [sp, #-16]!
+    stp x3, x4, [sp, #0x10]
+    stp x1, x2, [sp, #0x00]
 
     mov x0,  sp
     bl \handler
@@ -86,30 +87,31 @@ __exception_vector_start:
     el1_save_context_and_call_handler lower_el_aarch32_serror lower_el_aarch32_serror_str
 
 __exception_restore_context:
-    ldp x0, x1, [sp], #16
-    ldp x2, x3, [sp], #16
+    ldp x0, x1, [sp, #0x00]
+    ldp x2, x3, [sp, #0x10]
 
     msr ELR_EL1,  x0
     msr SPSR_EL1, x1
     msr SP_EL0, x3
 
-    ldp x0,  x1,  [sp], #16
-    ldp x2,  x3,  [sp], #16
-    ldp x4,  x5,  [sp], #16
-    ldp x6,  x7,  [sp], #16
-    ldp x8,  x9,  [sp], #16
-    ldp x10, x11, [sp], #16
-    ldp x12, x13, [sp], #16
-    ldp x14, x15, [sp], #16
-    ldp x16, x17, [sp], #16
-    ldp x18, x19, [sp], #16
-    ldp x20, x21, [sp], #16
-    ldp x22, x23, [sp], #16
-    ldp x24, x25, [sp], #16
-    ldp x26, x27, [sp], #16
-    ldp x28, x29, [sp], #16
-    ldr x30, [sp], #8
+    ldp x0,  x1,  [sp, #0x20]
+    ldp x2,  x3,  [sp, #0x30]
+    ldp x4,  x5,  [sp, #0x40]
+    ldp x6,  x7,  [sp, #0x50]
+    ldp x8,  x9,  [sp, #0x60]
+    ldp x10, x11, [sp, #0x70]
+    ldp x12, x13, [sp, #0x80]
+    ldp x14, x15, [sp, #0x90]
+    ldp x16, x17, [sp, #0xA0]
+    ldp x18, x19, [sp, #0xB0]
+    ldp x20, x21, [sp, #0xC0]
+    ldp x22, x23, [sp, #0xD0]
+    ldp x24, x25, [sp, #0xE0]
+    ldp x26, x27, [sp, #0xF0]
+    ldp x28, x29, [sp, #0x100]
+    ldr x30, [sp, #0x110]
 
+    add sp, sp, 0x120
     eret
 
 .size    __exception_restore_context, . - __exception_restore_context
@@ -117,22 +119,23 @@ __exception_restore_context:
 
 .macro el2_save_context_and_call_handler stringlabel
     // push all general purpose registers on the stack.
-    str x30, [sp, #-8]!
-    stp x28, x29, [sp, #-16]!
-    stp x26, x27, [sp, #-16]!
-    stp x24, x25, [sp, #-16]!
-    stp x22, x23, [sp, #-16]!
-    stp x20, x21, [sp, #-16]!
-    stp x18, x19, [sp, #-16]!
-    stp x16, x17, [sp, #-16]!
-    stp x14, x15, [sp, #-16]!
-    stp x12, x13, [sp, #-16]!
-    stp x10, x11, [sp, #-16]!
-    stp x8,  x9,  [sp, #-16]!
-    stp x6,  x7,  [sp, #-16]!
-    stp x4,  x5,  [sp, #-16]!
-    stp x2,  x3,  [sp, #-16]!
-    stp x0,  x1,  [sp, #-16]!
+    sub sp, sp, 0x100
+    str x30, [sp, #0xF0]
+    stp x28, x29, [sp, #0xE0]
+    stp x26, x27, [sp, #0xD0]
+    stp x24, x25, [sp, #0xC0]
+    stp x22, x23, [sp, #0xB0]
+    stp x20, x21, [sp, #0xA0]
+    stp x18, x19, [sp, #0x90]
+    stp x16, x17, [sp, #0x80]
+    stp x14, x15, [sp, #0x70]
+    stp x12, x13, [sp, #0x60]
+    stp x10, x11, [sp, #0x50]
+    stp x8,  x9,  [sp, #0x40]
+    stp x6,  x7,  [sp, #0x30]
+    stp x4,  x5,  [sp, #0x20]
+    stp x2,  x3,  [sp, #0x10]
+    stp x0,  x1,  [sp, #0x00]
 
     mov x0,  sp
     adr x1, \stringlabel


### PR DESCRIPTION
aapcs64 enforces the SP to be quad-word-aligned at all times. Given that
on entry the stack will be guaranteed to be 16-byte aligned, we just
need to make sure that on exception entry we keep proper alignment.