### PR TITLE
Fix TLB invalidation by VA

### DIFF
--- a/p1c0_kernel/src/arch/mmu.rs
+++ b/p1c0_kernel/src/arch/mmu.rs
@@ -621,7 +621,7 @@ pub fn flush_tlb_page(addr: VirtualAddress) {
 
     #[cfg(all(not(test), target_arch = "aarch64"))]
     unsafe {
-        core::arch::asm!("dsb ishst\n", "tlbi vaae1, x0\n", "dsb ish\n", "isb\n", in("x0") addr.as_u64());
+        core::arch::asm!("dsb ishst\n", "tlbi vaae1, x0\n", "dsb ish\n", "isb\n", in("x0") addr.page_number());
     }
 }
 

--- a/p1c0_kernel/src/memory/address.rs
+++ b/p1c0_kernel/src/memory/address.rs
@@ -1,5 +1,5 @@
 use crate::{
-    arch::mmu::PAGE_SIZE,
+    arch::mmu::{PAGE_BITS, PAGE_SIZE},
     memory::map::{KERNEL_LOGICAL_BASE, KERNEL_LOGICAL_SIZE},
 };
 
@@ -16,6 +16,10 @@ pub trait Address {
 
     fn is_page_aligned(&self) -> bool {
         (self.as_usize() & (PAGE_SIZE - 1)) == 0
+    }
+
+    fn page_number(&self) -> u64 {
+        self.as_u64() >> PAGE_BITS
     }
 
     fn as_mut_ptr(&self) -> *mut u8 {


### PR DESCRIPTION
It requires using the page number of the virtual address instead of the
virtual address itself.