### PR TITLE
Use kernel low page tables for kernel thread

### DIFF
--- a/p1c0_kernel/src/arch/exceptions.rs
+++ b/p1c0_kernel/src/arch/exceptions.rs
@@ -403,7 +403,6 @@ impl fmt::Display for ExceptionContext {
         if let Some(validator) = crate::thread::current_stack_validator() {
             // Stack trace
             let fp = VirtualAddress::new_unaligned(self.gpr[29] as *const _);
-
             let stack_iter = crate::backtrace::stack_frame_iter(fp, validator);
             write!(f, "{}", stack_iter)?;
         }

--- a/p1c0_kernel/src/backtrace.rs
+++ b/p1c0_kernel/src/backtrace.rs
@@ -2,7 +2,7 @@ use crate::memory::address::{Address, Validator, VirtualAddress};
 use core::fmt::Formatter;
 
 #[repr(C)]
-pub struct Frame {
+struct Frame {
     next: *const Frame,
     lr: *const u8,
 }

--- a/p1c0_kernel/src/memory.rs
+++ b/p1c0_kernel/src/memory.rs
@@ -467,4 +467,8 @@ impl MemoryManager {
 
         self.kernel_address_space.fast_page_unmap().unwrap();
     }
+
+    pub fn map_kernel_low_pages(&mut self) {
+        arch::mmu::switch_process_translation_table(self.kernel_address_space.low_table());
+    }
 }

--- a/p1c0_kernel/src/memory/address.rs
+++ b/p1c0_kernel/src/memory/address.rs
@@ -9,26 +9,37 @@ pub trait Validator {
 }
 
 pub trait Address {
+    #[must_use]
     fn as_ptr(&self) -> *const u8;
 
+    #[must_use]
     fn as_usize(&self) -> usize {
         self.as_ptr() as usize
     }
 
+    #[must_use]
     fn as_u64(&self) -> u64 {
         self.as_ptr() as u64
     }
 
+    #[must_use]
     fn is_page_aligned(&self) -> bool {
         (self.as_usize() & (PAGE_SIZE - 1)) == 0
     }
 
+    #[must_use]
     fn page_number(&self) -> u64 {
         self.as_u64() >> PAGE_BITS
     }
 
+    #[must_use]
     fn as_mut_ptr(&self) -> *mut u8 {
         self.as_ptr() as *mut _
+    }
+
+    #[must_use]
+    fn is_null(&self) -> bool {
+        self.as_ptr().is_null()
     }
 }
 

--- a/p1c0_kernel/src/thread.rs
+++ b/p1c0_kernel/src/thread.rs
@@ -307,6 +307,9 @@ fn restore_thread_context(cx: &mut ExceptionContext, thread: &Tcb) {
         do_with_process(handle, |process| {
             arch::mmu::switch_process_translation_table(process.address_space().address_table());
         });
+    } else {
+        // Set the kernel translation table instead
+        crate::memory::MemoryManager::instance().map_kernel_low_pages();
     }
 }
 


### PR DESCRIPTION
Just to make sure we don't accidentally access process data from kernel
threads.