### PR TITLE
Perform relocations in asm

### DIFF
--- a/fw/startup.S
+++ b/fw/startup.S
@@ -33,12 +33,12 @@ _configure_stack:
 
 _apply_relocations:
     adrp x0, _base
+    mov x1, x0
     mov x20, x0
-    adrp x1, _rela_start
-    add x1, x1, :lo12:_rela_start
-    adrp x2, _rela_end
-    add x2, x2, :lo12:_rela_end
-    sub x2, x2, x1
+    adrp x2, _rela_start
+    add x2, x2, :lo12:_rela_start
+    adrp x3, _rela_end
+    add x3, x3, :lo12:_rela_end
     bl apply_rela
 
 _jump_to_start_rust:
@@ -135,3 +135,49 @@ _uart_puthex:
 _uart_putendl:
     mov x0, '\n'
     b _uart_putc
+
+// Old Base x0
+// Base x1
+// rela Start x2
+// rela End x3
+.globl apply_rela
+.type apply_rela, @function
+apply_rela:
+    str x30, [sp, #-8]!
+    str x19, [sp, #-8]!
+    str x20, [sp, #-8]!
+
+1:
+    // If begin and end ptrs are equal we are at the end of the relocation list
+    cmp x2, x3
+    bhs 3f
+
+    // Load in x19 the rela.type
+    ldr x19, [x2, #8]
+
+    // Check if type is 1027
+    mov x30, #1027
+    cmp x19, x30
+    bne 2f
+
+    // It is a relative relocation, handle it
+    // ptr = Old base + rela.offset
+    ldr x19, [x2, #0]
+    add x19, x19, x0
+
+    // value = base + rela.addend
+    ldr x20, [x2, #16]
+    add x20, x20, x1
+
+    str x20, [x19]
+
+2:
+    // Goto next entry
+    add x2, x2, #24
+    b 1b
+
+3:
+    ldr x20, [sp], #8
+    ldr x19, [sp], #8
+    ldr x30, [sp], #8
+    ret

--- a/fw/startup.S
+++ b/fw/startup.S
@@ -181,3 +181,21 @@ apply_rela:
     ldr x19, [sp], #8
     ldr x30, [sp], #8
     ret
+
+// This function assumes the new address is in high memory!
+.globl relocate_and_jump_to_relocated_kernel
+.type relocate_and_jump_to_relocated_kernel, @function
+relocate_and_jump_to_relocated_kernel:
+    str x4, [sp, #-8]!
+    str x5, [sp, #-8]!
+
+    bl apply_rela
+
+    ldr x1, [sp], #8
+    ldr x0, [sp], #8
+
+    mov x30, x0
+    mov sp, x1
+
+    dsb sy
+    ret

--- a/p1c0_kernel/src/arch.rs
+++ b/p1c0_kernel/src/arch.rs
@@ -1,9 +1,6 @@
 use crate::log_debug;
 use crate::memory::address::VirtualAddress;
-use cortex_a::{
-    asm,
-    registers::{CurrentEL, SPSel},
-};
+use cortex_a::registers::{CurrentEL, SPSel};
 use tock_registers::interfaces::Readable;
 
 pub mod cache;
@@ -51,25 +48,6 @@ pub fn read_pc() -> *const () {
 #[cfg(not(target_arch = "aarch64"))]
 pub fn read_pc() -> *const () {
     core::ptr::null()
-}
-
-#[inline(always)]
-/// # Safety
-/// The stack pointer must be valid, as well as the jumping address. From this point onwards, the
-/// previous memory in the stack will no longer be accessible. Therefore references to the stack
-/// will not be valid anymore.
-pub unsafe fn jump_to_addr(_addr: usize, _stack_ptr: *const u8) -> ! {
-    #[cfg(target_arch = "aarch64")]
-    core::arch::asm!(
-        "mov sp, {}",
-        "dsb sy",
-        "blr {}",
-        in(reg) _stack_ptr,
-        in(reg) _addr);
-
-    loop {
-        asm::wfi();
-    }
 }
 
 pub enum StackType {

--- a/p1c0_kernel/src/arch.rs
+++ b/p1c0_kernel/src/arch.rs
@@ -10,64 +10,6 @@ pub mod cache;
 pub mod exceptions;
 pub mod mmu;
 
-#[repr(C)]
-pub struct RelaEntry {
-    offset: usize,
-    ty: usize,
-    addend: usize,
-}
-
-const R_AARCH64_RELATIVE: usize = 1027;
-
-/// Applies relative offsets during boot to relocate the binary.
-///
-/// # Safety
-///   `rela_start` must point to valid memory, at the start of the relocatable information
-///   `rela_len_bytes` must be larger than 0 and indicate the size of the slice in bytes.
-///   Other regular conditions must hold when calling thsi function (e.g.: having a valid SP)
-#[no_mangle]
-pub unsafe extern "C" fn apply_rela(
-    base: usize,
-    rela_start: *const RelaEntry,
-    rela_len_bytes: usize,
-) {
-    let rela_len = rela_len_bytes / core::mem::size_of::<RelaEntry>();
-    let relocations = &*core::ptr::slice_from_raw_parts(rela_start, rela_len);
-
-    for relocation in relocations {
-        let ptr = (base + relocation.offset) as *mut usize;
-        match relocation.ty {
-            R_AARCH64_RELATIVE => *ptr = base + relocation.addend,
-            _ => unimplemented!(),
-        };
-    }
-}
-
-/// Applies relative offsets during boot to relocate the binary.
-///
-/// # Safety
-///   `rela_start` must point to valid memory, at the start of the relocatable information
-///   `rela_len_bytes` must be larger than 0 and indicate the size of the slice in bytes.
-///   Other regular conditions must hold when calling thsi function (e.g.: having a valid SP)
-///   old_base must point to an existing mapping to be relocated
-pub unsafe fn apply_rela_from_existing(
-    old_base: usize,
-    base: usize,
-    rela_start: *const RelaEntry,
-    rela_len_bytes: usize,
-) {
-    let rela_len = rela_len_bytes / core::mem::size_of::<RelaEntry>();
-    let relocations = &*core::ptr::slice_from_raw_parts(rela_start, rela_len);
-
-    for relocation in relocations {
-        let ptr = (old_base + relocation.offset) as *mut usize;
-        match relocation.ty {
-            R_AARCH64_RELATIVE => *ptr = base + relocation.addend,
-            _ => unimplemented!(),
-        };
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum ExceptionLevel {
     Application,


### PR DESCRIPTION
Doing this in rust code has never been safe, as it is impossible to know
if the code actually depends on the relocations being valid already.