### PR TITLE
Remove overlapping physical memory ranges

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -119,5 +119,5 @@ ensure_gcc
 
 write_env
 
-cargo install cargo-binutils
-cargo install grcov
+cargo install cargo-binutils --locked
+cargo install grcov --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 
+resolver = "2"
+
 members = [
     "p1c0_kernel",
     "p1c0_macros",

--- a/drivers/Cargo.toml
+++ b/drivers/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "driver-helper",

--- a/drivers/virtio/src/main.rs
+++ b/drivers/virtio/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+#[allow(unused_imports)]
 pub use driver_helper as _;
 
 #[no_mangle]

--- a/fw/src/lib.rs
+++ b/fw/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![cfg_attr(test, no_main)]
-#![cfg_attr(test, feature(default_alloc_error_handler))]
 #![cfg_attr(test, feature(custom_test_frameworks))]
 #![cfg_attr(test, test_runner(test_fwk::runner))]
 #![cfg_attr(test, reexport_test_harness_main = "test_main")]

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![no_main]
-#![feature(default_alloc_error_handler)]
 
 use p1c0::print_boot_args;
 
@@ -87,8 +86,7 @@ fn kernel_entry() {
         )
         .unwrap();
 
-        let mut elf_data = vec![];
-        elf_data.resize(file.size, 0);
+        let mut elf_data = vec![0; file.size];
         p1c0_kernel::filesystem::VirtualFileSystem::read(&mut file, &mut elf_data[..]).unwrap();
         p1c0_kernel::filesystem::VirtualFileSystem::close(file);
         let builder =
@@ -117,7 +115,9 @@ fn finish() -> ! {
     arm_semihosting::exit(1);
 
     #[cfg(not(feature = "emulator"))]
-    loop {}
+    loop {
+        aarch64_cpu::asm::wfi();
+    }
 }
 
 #[panic_handler]

--- a/fw/tests/adt_tests.rs
+++ b/fw/tests/adt_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/fw/tests/aic_tests.rs
+++ b/fw/tests/aic_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 #![feature(assert_matches)]
 
 use p1c0 as _; // needed to link libentry (and _start)

--- a/fw/tests/backtracer_tests.rs
+++ b/fw/tests/backtracer_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/fw/tests/initcall_tests.rs
+++ b/fw/tests/initcall_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/fw/tests/process_tests.rs
+++ b/fw/tests/process_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/fw/tests/sync_tests.rs
+++ b/fw/tests/sync_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/fw/tests/syscall_tests.rs
+++ b/fw/tests/syscall_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/fw/tests/thread_tests.rs
+++ b/fw/tests/thread_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/fw/tests/unknown_syscall_tests.rs
+++ b/fw/tests/unknown_syscall_tests.rs
@@ -3,7 +3,6 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(test_fwk::runner_should_panic)]
 #![reexport_test_harness_main = "test_main"]
-#![feature(default_alloc_error_handler)]
 
 use p1c0 as _; // needed to link libentry (and _start)
 

--- a/p1c0_kernel/src/arch/mmu.rs
+++ b/p1c0_kernel/src/arch/mmu.rs
@@ -586,7 +586,7 @@ impl LevelTable {
     }
 }
 
-pub fn switch_process_translation_table(low_table: &mut LevelTable) {
+pub fn switch_process_translation_table(low_table: &LevelTable) {
     let va = LogicalAddress::try_from_ptr(low_table.as_ptr() as *mut _)
         .expect("Level table not aligned!!");
     let pa = va.into_physical();
@@ -616,7 +616,7 @@ pub fn flush_tlb_page(addr: VirtualAddress) {
     }
 }
 
-pub fn initialize(high_table: &mut LevelTable, low_table: &mut LevelTable) {
+pub fn initialize(high_table: &LevelTable, low_table: &LevelTable) {
     if unsafe { MMU_INITIALIZED } {
         panic!("MMU Already initialized!");
     }

--- a/p1c0_kernel/src/collections/intrusive_list.rs
+++ b/p1c0_kernel/src/collections/intrusive_list.rs
@@ -356,7 +356,7 @@ mod test {
         assert_eq!(vector, vec![32, 23, 84, 843]);
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 
@@ -381,7 +381,7 @@ mod test {
         assert_eq!(vector, vec![843, 84, 23, 32]);
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 
@@ -408,7 +408,7 @@ mod test {
         assert_eq!(iter.next_back(), None);
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 
@@ -429,13 +429,13 @@ mod test {
         let removed_element = list.pop().expect("There is no element to pop");
         assert_eq!(*removed_element.deref().deref(), 32);
 
-        unsafe { removed_element.into_box() };
+        let _ = unsafe { removed_element.into_box() };
 
         let vector: Vec<_> = list.iter().map(|item| item.inner).collect();
         assert_eq!(vector, vec![23, 84]);
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 
@@ -456,13 +456,13 @@ mod test {
         let removed_element = list.remove(1).expect("Could not remove element");
         assert_eq!(*removed_element.deref().deref(), 23);
 
-        unsafe { removed_element.into_box() };
+        let _ = unsafe { removed_element.into_box() };
 
         let vector: Vec<_> = list.iter().map(|item| item.inner).collect();
         assert_eq!(vector, vec![32, 84]);
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 
@@ -493,11 +493,11 @@ mod test {
         assert_eq!(vector, vec![84, 84]);
 
         removed_list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 
@@ -533,7 +533,7 @@ mod test {
         assert_eq!(vector, vec![32, 23, 234, 84, 84]);
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 
@@ -574,7 +574,7 @@ mod test {
         assert_eq!(iter.next_back(), None);
 
         list.release(|element| {
-            unsafe { element.into_box() };
+            let _ = unsafe { element.into_box() };
         });
     }
 

--- a/p1c0_kernel/src/crc.rs
+++ b/p1c0_kernel/src/crc.rs
@@ -1,7 +1,7 @@
 mod crc16 {
     const POLY: u16 = 0xA001; // x^16 + x^15 + x^2 + 1
 
-    #[no_coverage]
+    #[coverage(off)]
     const fn generate_coefficient(byte: u8) -> u16 {
         let mut value: u16 = byte as u16;
 
@@ -20,7 +20,7 @@ mod crc16 {
         value
     }
 
-    #[no_coverage]
+    #[coverage(off)]
     const fn generate_table() -> [u16; 256] {
         let mut table = [0; 256];
         let mut i = 0;
@@ -60,7 +60,7 @@ pub fn crc16(seed: u16, data: &[u8]) -> u16 {
 mod crc32c {
     const POLY: u32 = 0x82F63B78; // CRC32C
 
-    #[no_coverage]
+    #[coverage(off)]
     const fn generate_coefficient(byte: u8) -> u32 {
         let mut value = byte as u32;
 
@@ -79,7 +79,7 @@ mod crc32c {
         value
     }
 
-    #[no_coverage]
+    #[coverage(off)]
     const fn generate_table() -> [u32; 256] {
         let mut table = [0; 256];
         let mut i = 0;

--- a/p1c0_kernel/src/drivers/aic.rs
+++ b/p1c0_kernel/src/drivers/aic.rs
@@ -207,7 +207,7 @@ struct AicDriver {}
 impl super::Driver for AicDriver {
     fn probe(&self, dev_path: &[adt::AdtNode]) -> super::Result<super::DeviceRef> {
         log_error!("Probing aic driver");
-        let dev = Aic::probe(dev_path).map_err(|e| super::Error::DeviceSpecificError(e))?;
+        let dev = Aic::probe(dev_path).map_err(super::Error::DeviceSpecificError)?;
         Ok(dev)
     }
 }

--- a/p1c0_kernel/src/drivers/display.rs
+++ b/p1c0_kernel/src/drivers/display.rs
@@ -78,13 +78,19 @@ impl Display {
             .try_into_logical()
             .expect("Framebuffer does not have a logical address");
 
-        memory::MemoryManager::instance().map_logical(
-            "framebuffer",
-            la,
-            size,
-            Attributes::Normal,
-            Permissions::RW,
-        )?;
+        // SAFETY:
+        //   This is safe because the memory range passed to our kernel already does not contain
+        //   the pages reserved for the framebuffer, but they are still regular ram (And should be
+        //   mapped as such to give nice read/write performance).
+        unsafe {
+            memory::MemoryManager::instance().map_logical_reserved(
+                "framebuffer",
+                la,
+                size,
+                Attributes::Normal,
+                Permissions::RW,
+            )?
+        };
 
         Ok(la.as_ptr() as *mut u32)
     }

--- a/p1c0_kernel/src/drivers/interfaces/mod.rs
+++ b/p1c0_kernel/src/drivers/interfaces/mod.rs
@@ -40,6 +40,6 @@ impl TimerResolution {
     }
 
     pub fn duration_to_ticks(&self, duration: Duration) -> Ticks {
-        Ticks(((duration.as_nanos() as u128 * self.0 as u128) / Self::S_IN_NS as u128) as u64)
+        Ticks(((duration.as_nanos() * self.0 as u128) / Self::S_IN_NS) as u64)
     }
 }

--- a/p1c0_kernel/src/drivers/spi.rs
+++ b/p1c0_kernel/src/drivers/spi.rs
@@ -213,7 +213,7 @@ fn pointer_alignment<T>(ptr: *const T) -> usize {
 
 /// This function checks the alignment and size of the slices to obtain the best fit
 /// transaction size that does not result in UB
-fn deduct_transaction_size(tx_data: &[u8], rx_data: &mut [MaybeUninit<u8>]) -> TransactionSize {
+fn deduct_transaction_size(tx_data: &[u8], rx_data: &[MaybeUninit<u8>]) -> TransactionSize {
     let tx_alignment = pointer_alignment(tx_data.as_ptr());
     let rx_alignment = pointer_alignment(tx_data.as_ptr());
     if tx_alignment >= 4
@@ -412,14 +412,14 @@ impl Spi {
                     let bytes = u16::to_be_bytes(rx_data as u16);
                     for byte in bytes {
                         let slot = rx_data_iter.next().unwrap_unchecked();
-                        slot.write(byte as u8);
+                        slot.write(byte);
                     }
                 }
                 TransactionSize::Ts4b => {
                     let bytes = u32::to_be_bytes(rx_data);
                     for byte in bytes {
                         let slot = rx_data_iter.next().unwrap_unchecked();
-                        slot.write(byte as u8);
+                        slot.write(byte);
                     }
                 }
             }

--- a/p1c0_kernel/src/drivers/virtio/virtqueue.rs
+++ b/p1c0_kernel/src/drivers/virtio/virtqueue.rs
@@ -185,8 +185,7 @@ impl<const N: usize, const C: usize> VirtQueue<N, C> {
             .iter_mut()
             .zip(self.descriptor_data.iter_mut())
         {
-            let buffer_pa =
-                LogicalAddress::new_unaligned(buffer.as_mut_ptr() as *mut u8).into_physical();
+            let buffer_pa = LogicalAddress::new_unaligned(buffer.as_mut_ptr()).into_physical();
 
             desc.addr.set(buffer_pa.as_u64());
             desc.len.set(buffer.len() as u32);

--- a/p1c0_kernel/src/lib.rs
+++ b/p1c0_kernel/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(allocator_api)]
 #![feature(maybe_uninit_as_bytes)]
 #![feature(maybe_uninit_slice)]
-#![feature(no_coverage)]
+#![feature(coverage_attribute)]
 
 pub mod adt;
 pub mod arch;

--- a/p1c0_kernel/src/memory/address.rs
+++ b/p1c0_kernel/src/memory/address.rs
@@ -168,6 +168,14 @@ impl PhysicalAddress {
         Self(addr_usize as *const u8)
     }
 
+    #[must_use]
+    pub fn align_up_to_page(&self) -> Self {
+        let mut addr_usize = self.0 as usize;
+        addr_usize += PAGE_SIZE - 1;
+        addr_usize &= !(PAGE_SIZE - 1);
+        Self(addr_usize as *const u8)
+    }
+
     /// # Safety
     ///   The user must guarantee that the resulting pointer is a valid PhysicalAddress after this
     ///   operation. This means that it is within the limits of addressable physical memory and

--- a/p1c0_kernel/src/memory/address_space.rs
+++ b/p1c0_kernel/src/memory/address_space.rs
@@ -451,7 +451,7 @@ impl ProcessAddressSpace {
     }
 
     pub(crate) fn address_table(&mut self) -> &mut LevelTable {
-        &mut *self.address_table
+        &mut self.address_table
     }
 
     pub fn map_section(

--- a/p1c0_kernel/src/process.rs
+++ b/p1c0_kernel/src/process.rs
@@ -260,7 +260,7 @@ impl Builder {
                 mapped_env_addresses.push(core::ptr::null());
 
                 let mut copy_slice = |slice: &[*const u8]| {
-                    let size_bytes = slice.len() * core::mem::size_of::<*const u8>();
+                    let size_bytes = core::mem::size_of_val(slice);
 
                     // Align offset to pointer size
                     let alignment = offset % core::mem::size_of::<*const u8>();
@@ -329,7 +329,7 @@ impl Builder {
     }
 
     pub fn new_from_elf_data(name: &str, elf_data: Vec<u8>, aslr: usize) -> Result<Builder, Error> {
-        let elf = ElfParser::from_slice(&elf_data[..]).map_err(|e| Error::ElfError(e))?;
+        let elf = ElfParser::from_slice(&elf_data[..]).map_err(Error::ElfError)?;
         if !matches!(
             elf.elf_type(),
             elf::EType::Executable | elf::EType::SharedObject
@@ -340,7 +340,7 @@ impl Builder {
 
         let mut process_builder = Builder::new();
         for header in elf.program_header_iter() {
-            let header_type = header.ty().map_err(|e| Error::ElfError(e))?;
+            let header_type = header.ty().map_err(Error::ElfError)?;
             if matches!(header_type, elf::PtType::Load) {
                 log_debug!(
                     "Virtual addr 0x{:x}, Physical addr 0x{:x}, Size in process {} Size in file {}",
@@ -390,7 +390,7 @@ impl Builder {
 
                 process_builder.map_section(
                     elf.matching_section_name(&header)
-                        .map_err(|e| Error::ElfError(e))?
+                        .map_err(Error::ElfError)?
                         .unwrap_or(""),
                     vaddr,
                     header.memsize() as usize,

--- a/p1c0_kernel/src/thread.rs
+++ b/p1c0_kernel/src/thread.rs
@@ -196,7 +196,7 @@ impl Builder {
 
         const DEFAULT_STACK_SIZE: usize = 1024;
 
-        let name = self.name.unwrap_or_else(String::new);
+        let name = self.name.unwrap_or_default();
         let stack_size = self.stack_size.unwrap_or(DEFAULT_STACK_SIZE);
         let stack = Stack::new(stack_size);
         let stack_ptr = stack.top();
@@ -428,7 +428,7 @@ fn exit_thread(thread: Tcb) {
     let tid = thread.tid;
 
     // Drop the thread
-    unsafe { thread.into_box() };
+    let _ = unsafe { thread.into_box() };
 
     // Get the TID and unlock any threads that were waiting for this one to complete
     let unblocked_threads = BLOCKED_THREADS.lock().drain_filter(|thread| {

--- a/p1c0_macros/src/lib.rs
+++ b/p1c0_macros/src/lib.rs
@@ -149,12 +149,12 @@ impl RegisterBank {
             let offset: usize = register.offset.base10_parse().unwrap();
             if (offset % reg_size) != 0 {
                 let error_message = format!("Register `{}` is unaligned", register.name);
-                return Err(syn::Error::new(register.offset.span(), &error_message));
+                return Err(syn::Error::new(register.offset.span(), error_message));
             }
 
             if offset < current_offset {
                 let error_message = format!("Register `{}` overlaps with another", register.name);
-                return Err(syn::Error::new(register.offset.span(), &error_message));
+                return Err(syn::Error::new(register.offset.span(), error_message));
             }
 
             current_offset = offset + reg_size;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-06-20"
+channel = "nightly-2023-09-23"
 components = [ "rust-src", "clippy", "rustfmt", "rustc", "rust-std", "llvm-tools-preview" ]
 targets = [ "aarch64-unknown-none-softfloat" ]


### PR DESCRIPTION
Even though the ADT gives us the information of the complete RAM range, we may not use much of that due to carveouts. Some carveouts are already accounted for, but unfortunately looks like there is more than initially anticipated.

This change ensures that the available physical memory is only that given to us by iBoot (or forwarded by m1n1) when we boot.